### PR TITLE
switch gulp watcher to launch under different npm command

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -7,7 +7,7 @@
 To start a Browser Sync server
 
 ```
-npm start
+npm run dev
 ```
 
 or to build, cachebust, and minify all assets for production

--- a/{{ cookiecutter.repo_name }}/package.json
+++ b/{{ cookiecutter.repo_name }}/package.json
@@ -4,7 +4,7 @@
   "description": "{{ cookiecutter.description }}",
   "scripts": {
     "build": "gulp build:production",
-    "start": "gulp start"
+    "dev": "gulp start"
   },
   "author": "{{ cookiecutter.author }}",
   "dependencies": {


### PR DESCRIPTION
`npm start` is typically understood as the command to launch an application (See [here](https://docs.npmjs.com/cli/start)). It was being used here to start a dev server. I changed it to be `npm run dev` which seems more appropriate 