### PR TITLE
Path bug fix

### DIFF
--- a/{{ cookiecutter.repo_name }}/gulpfile.js
+++ b/{{ cookiecutter.repo_name }}/gulpfile.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path           = require('path');
 const gulp           = require('gulp');
 const gutil          = require('gulp-util');
 const del            = require('del');


### PR DESCRIPTION
A new cookiecutter instance was failing on gulp start
```
ReferenceError: path is not defined
at Gulp.<anonymous> (/Users/LOANER/Developer/modstock-static/gulpfile.js:72:24)
```