### PR TITLE
fixed issue on initial npm start after npm install

### DIFF
--- a/{{ cookiecutter.repo_name }}/gulpfile.js
+++ b/{{ cookiecutter.repo_name }}/gulpfile.js
@@ -4,7 +4,6 @@ const path           = require('path');
 const gulp           = require('gulp');
 const gutil          = require('gulp-util');
 const del            = require('del');
-const concat         = require('gulp-concat');
 const browserSync    = require('browser-sync').create();
 const autoprefixer   = require('autoprefixer');
 const postcss        = require('gulp-postcss');

--- a/{{ cookiecutter.repo_name }}/package.json
+++ b/{{ cookiecutter.repo_name }}/package.json
@@ -19,6 +19,7 @@
     {% if cookiecutter.use_foundation_sites == 'y' -%}"foundation-sites": "6.1.2",{%- endif %}
     "gulp": "3.9.0",
     "gulp-cssnano": "2.1.0",
+    "gulp-concat": "2.6.0",
     "gulp-htmlmin": "1.2.0",
     "gulp-if": "2.0.0",
     "gulp-nunjucks-render": "1.0.0",

--- a/{{ cookiecutter.repo_name }}/package.json
+++ b/{{ cookiecutter.repo_name }}/package.json
@@ -19,7 +19,6 @@
     {% if cookiecutter.use_foundation_sites == 'y' -%}"foundation-sites": "6.1.2",{%- endif %}
     "gulp": "3.9.0",
     "gulp-cssnano": "2.1.0",
-    "gulp-concat": "2.6.0",
     "gulp-htmlmin": "1.2.0",
     "gulp-if": "2.0.0",
     "gulp-nunjucks-render": "1.0.0",


### PR DESCRIPTION
Ran into an issue when creating a new website from cookiecutter that it was missing gulp concat after an `npm install`.