### PR TITLE
Added ignored files + indentation fix

### DIFF
--- a/{{ cookiecutter.repo_name }}/.stylelintrc
+++ b/{{ cookiecutter.repo_name }}/.stylelintrc
@@ -1,10 +1,13 @@
 {
   "extends": "stylelint-config-standard",
+  "ignoreFiles": [
+    "src/scss/_settings.scss"
+  ],
   "plugins": [
     "stylelint-selector-bem-pattern"
   ],
   "rules": {
-    "indentation": 4,
+    "indentation": null,
     "max-empty-lines": 2,
     "no-browser-hacks",
     "no-unsupported-browser-features": [ true, {


### PR DESCRIPTION
This fixes some of the issues we're facing with mo-static.
- Indentation is not being checked and logged anymore since there is no identation plugin that satisfies our needs according to the styleguide we use
- Added an `ignoredFiles` array to `.stylelintrc`, by default it holds foundation's `_settings.scss` since it cause errors. Another great file to add here is `_fonts.scss`
