### PR TITLE
Fixed heroku static build error

### DIFF
--- a/{{ cookiecutter.repo_name }}/gulpfile.babel.js
+++ b/{{ cookiecutter.repo_name }}/gulpfile.babel.js
@@ -1,6 +1,5 @@
 import gulp from 'gulp'
 import runSequence from 'run-sequence'
-import browserSync from 'browser-sync'
 import './gulp/build'
 import './gulp/production'
 import './gulp/utils'
@@ -17,6 +16,7 @@ gulp.task('build:production', (done) => {
 })
 
 gulp.task('watch', ['build', 'watchify'], () => {
+  const browserSync = require('browser-sync')
   browserSync({
     server: 'public',
     files: 'public/**/*',


### PR DESCRIPTION
`browser-sync` is a development dependency in `package.json` but is required in the gulpfile. As a result when you try to run `NODE_ENV=production npm install`, it errored out since it couldn't find `browser-sync`.

Solution
Removed the global es6 import and did a `require` within the watch task instead
