### PR TITLE
Webpack2 Foundation Fix

### DIFF
--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -12,6 +12,7 @@
   "author": "{{ cookiecutter.author_name }}",
   "dependencies": {
     "autoprefixer": "6.1.0",
+    "babel-loader": "^6.3.2",
     "babel-core": "6.9.1",
     "babel-plugin-syntax-trailing-function-commas": "6.5.0",
     "babel-preset-es2015": "6.1.4",
@@ -41,6 +42,7 @@
     "loose-envify": "1.1.0",
     "nconf": "0.8.4",
     "run-sequence": "1.1.4",
+    "script-loader": "^0.7.0",
     "stylelint": "7.6.0",
     "stylelint-config-standard": "11.0.0",
     "stylelint-selector-bem-pattern": "1.0.0",

--- a/{{cookiecutter.repo_name}}/src/static/js/app.js
+++ b/{{cookiecutter.repo_name}}/src/static/js/app.js
@@ -1,7 +1,8 @@
 {% if cookiecutter.use_foundation_sites == 'y' -%}
-import $ from 'jquery'
-import 'foundation'
-import 'foundation-mediaquery'
+import 'script-loader!jquery'
+import 'script-loader!jquery-migrate'
+import 'script-loader!foundation-sites'
+import 'script-loader!foundation-sites/js/foundation.util.mediaQuery.js'
 
 
 // initialize foundation

--- a/{{cookiecutter.repo_name}}/webpack.config.js
+++ b/{{cookiecutter.repo_name}}/webpack.config.js
@@ -5,6 +5,20 @@ const config = {
   output: {
     path: path.resolve(__dirname, 'public/static/js'),
     filename: 'bundle.js'
+  },
+  module: {
+    loaders: [
+      { test: /\.js$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/
+      }
+    ],
+    rules: [
+      {
+        test: /\.exec.js$/,
+        use: ['script-loader']
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
# Makes foundation work with Webpack. 

It works but that's also all you can say about it. Foundation has never followed the UMD module pattern (hence the tricks we needed to do in our `package.json` with Browserify) and it also doesn't play **that** nicely with Webpack either. 

## Future 😬
They are apparently gonna try to start ES2016 import syntax in foundation 6.4 (6.3 is the latest at the time of writing). Module import support would this make a lot nicer but we aren't there yet. This fixes it by installing `script-loader` and using that to import foundation packages. More information can be found on [this](https://github.com/zurb/foundation-sites/issues/7386) Foundation issue.

## My Opinion 💁🏼
This is a PR that I'd rather not see merged, I don't like this "fix" and I think it's a good reason to kill Foundation altogether. I'd love for us to talk about it either at the office or here on this issue. Let's list the issues it has:
- It doesn't work nicely with Browserify or Webpack
- It requires jQuery & jQuery migrate
- It's a considerable amount of kb if you take Foundation, jQuery and jQuery migrate

## What's Next 🤔
If we do decide that we want to keep it; I'll update the readme with some extra info!
