### PR TITLE
Rearranging devdeps, improving package.json readability

### DIFF
--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -10,20 +10,31 @@
     "tinify": "gulp tinify"
   },
   "author": "{{ cookiecutter.author_name }}",
+  {% if cookiecutter.use_foundation_sites == 'y' -%}
   "dependencies": {
+    "foundation-sites": "6.2.3",
+    "jquery": "3.0.0"
+  },
+  {%- endif %}
+  "devDependencies": {
     "autoprefixer": "6.1.0",
     "babel-core": "6.9.1",
     "babel-plugin-syntax-trailing-function-commas": "6.5.0",
     "babel-preset-es2015": "6.1.4",
     "babelify": "7.2.0",
-    "browserify": "12.0.1",{% if cookiecutter.use_foundation_sites == 'y' -%}
-    "browserify-shim": "3.8.12",{%- endif %}
+    "browserify": "12.0.1",
+    {% if cookiecutter.use_foundation_sites == 'y' -%}
+    "browserify-shim": "3.8.12",
+    {%- endif %}
+    "browser-sync": "2.10.0",
     "critical": "github:addyosmani/critical#6a2e129",
     "del": "2.0.2",
     "eslint": "2.7.0",
     "eslint-config-airbnb": "6.2.0",
-    "eslint-plugin-react": "4.3.0",{% if cookiecutter.use_foundation_sites == 'y' -%}
-    "foundation-sites": "6.2.3",{%- endif %}
+    {% if cookiecutter.use_foundation_sites == 'y' -%}
+    "eslint-plugin-react": "4.3.0",
+    {%- endif %}
+    "foundation-sites": "6.2.3",
     "gulp": "3.9.0",
     "gulp-clean-css": "2.0.4",
     "gulp-header": "1.8.2",
@@ -38,8 +49,9 @@
     "gulp-sourcemaps": "1.6.0",
     "gulp-tinify": "1.0.2",
     "gulp-uglify": "1.4.2",
-    "gulp-util": "3.0.6",{% if cookiecutter.use_foundation_sites == 'y' -%}
-    "jquery": "3.0.0",{%- endif %}
+    {% if cookiecutter.use_foundation_sites == 'y' -%}
+    "gulp-util": "3.0.6",
+    {%- endif %}
     "loose-envify": "1.1.0",
     "nconf": "0.8.4",
     "run-sequence": "1.1.4",
@@ -48,12 +60,10 @@
     "stylelint-selector-bem-pattern": "1.0.0",
     "uglifyify": "3.0.1",
     "vinyl-buffer": "1.0.0",
-    "vinyl-source-stream": "1.1.0"
-  },
-  "devDependencies": {
-    "browser-sync": "2.10.0",
+    "vinyl-source-stream": "1.1.0",
     "watchify": "3.6.0"
-  },{% if cookiecutter.use_foundation_sites == 'y' -%}
+  },
+  {% if cookiecutter.use_foundation_sites == 'y' -%}
   "browser": {
     "jquery": "./node_modules/jquery/dist/jquery.js",
     "foundation": "./node_modules/foundation-sites/js/foundation.core.js",
@@ -63,7 +73,8 @@
     "jquery": "$",
     "foundation": { "exports": "Foundation",  "depends": "jquery" },
     "foundation-mediaquery": { "depends": "foundation" }
-  },{%- endif %}
+  },
+  {%- endif %}
   "browserify": {
     "transform": [
       "babelify"{% if cookiecutter.use_foundation_sites == 'y' -%},


### PR DESCRIPTION
There are a few deps in the `dependencies` section of `package.json` that could be pulled out to `devDependencies`, and I also moved some cookiecutter conditionals around to make the dependencies easier to read.

Saw there's a big refactor of mo static coming, looks really cool. Hope y'all are doing good :v: